### PR TITLE
chore: use node 16 for frontend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 # frontend/Dockerfile
 
-FROM node:18
+FROM node:16
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Summary
- use node 16 base image for frontend Dockerfile

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`
- `npm run dev`
- `docker build -t frontend-image-test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896700d9f20833385892019a0a9594f